### PR TITLE
[fix-repository -> master] select 개선 및 insertOrUpdate 버그 픽스

### DIFF
--- a/src/main/java/com/bookie/scrap/common/domain/Repository.java
+++ b/src/main/java/com/bookie/scrap/common/domain/Repository.java
@@ -1,10 +1,11 @@
 package com.bookie.scrap.common.domain;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface Repository<T> {
 
-    Optional<T> select(String code);
+    List<T> select(String code);
 
     boolean insertOrUpdate(T dto);
 

--- a/src/main/java/com/bookie/scrap/watcha/repository/WatchaBookMetaRepository.java
+++ b/src/main/java/com/bookie/scrap/watcha/repository/WatchaBookMetaRepository.java
@@ -6,9 +6,11 @@ import com.bookie.scrap.common.domain.Repository;
 import com.bookie.scrap.watcha.entity.WatchaBookEntity;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.NonUniqueResultException;
 import lombok.extern.slf4j.Slf4j;
 
-import java.util.Optional;
+import java.sql.SQLDataException;
+import java.util.List;
 
 @Slf4j
 public class WatchaBookMetaRepository implements Repository<WatchaBookEntity> {
@@ -25,19 +27,19 @@ public class WatchaBookMetaRepository implements Repository<WatchaBookEntity> {
     }
 
     @Override
-    public Optional<WatchaBookEntity> select(String bookCode) {
+    public List<WatchaBookEntity> select(String bookCode) {
         try (EntityManager em = emf.createEntityManager()) {
 
             String jpql = "SELECT w FROM WatchaBookEntity w WHERE w.bookCode = :bookCode";
 
-            WatchaBookEntity entity = em.createQuery(jpql, WatchaBookEntity.class)
+            List<WatchaBookEntity> results = em.createQuery(jpql, WatchaBookEntity.class)
                     .setParameter("bookCode", bookCode)
-                    .getSingleResult();
+                    .getResultList();
 
-            return Optional.ofNullable(entity);
+            return results;
         } catch (Exception e) {
-            log.error("An error occurred while selecting an entity with code: {}", bookCode, e);
-            return Optional.empty();
+            log.error("Error selecting entity with bookCode: {}", bookCode, e);
+            throw e;
         }
     }
 
@@ -50,18 +52,21 @@ public class WatchaBookMetaRepository implements Repository<WatchaBookEntity> {
 
             String jpql = "SELECT e FROM WatchaBookEntity e WHERE e.bookCode = :bookCode";
 
-            WatchaBookEntity existingEntity =
-                    em.createQuery(jpql, WatchaBookEntity.class)
-                            .setParameter("bookCode", targetEntity.getBookCode())
-                            .getSingleResult();
+            List<WatchaBookEntity> existingEntities = em.createQuery(jpql, WatchaBookEntity.class)
+                    .setParameter("bookCode", targetEntity.getBookCode())
+                    .getResultList();
 
-            if (existingEntity != null) {
+            if (existingEntities.isEmpty()) {
+                em.persist(targetEntity);
+                log.info("insert: {}", targetEntity);
+            } else if (existingEntities.size() == 1) {
+                WatchaBookEntity existingEntity = existingEntities.get(0);
                 existingEntity.updateEntity(targetEntity);
                 log.info("update: {}", existingEntity);
             } else {
-                em.persist(targetEntity);
-                log.info("insert: {}", targetEntity);
+                throw new NonUniqueResultException("select result is multiple: " + existingEntities.size());
             }
+
             em.getTransaction().commit();
 
             return true;

--- a/src/test/java/com/bookie/scrap/watcha/repository/WatchaBookMetaRepositoryTest.java
+++ b/src/test/java/com/bookie/scrap/watcha/repository/WatchaBookMetaRepositoryTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import java.util.Optional;
+import java.util.List;
 
 class WatchaBookMetaRepositoryTest {
 
@@ -28,9 +28,8 @@ class WatchaBookMetaRepositoryTest {
 
     @Test
     public void selectTest() {
-        Optional<WatchaBookEntity> select = WatchaBookMetaRepository.getInstance().select("byLKj8M");
-        Assertions.assertTrue(select.isPresent());
-        Assertions.assertEquals("byLKj8M", select.get().getBookCode());
+        List<WatchaBookEntity> results = WatchaBookMetaRepository.getInstance().select("byLKj8M");
     }
+
 
 }


### PR DESCRIPTION
- select에서 조회 결과 전체 반환, 이후 처리는 서비스 로직에서 처리하도록 개선
- insertOrUpdate에서 singleResult 반환 시 예외 발생하여 resultList로 반환하도록 변경
- insertOrUpdate에서 IllegalStateException`을 사용하여 예상치 못한 다중 데이터 처리 방지